### PR TITLE
Documentation corrected to match a recent code change

### DIFF
--- a/Products/Brass-Beta/Acting-as-Provider.md
+++ b/Products/Brass-Beta/Acting-as-Provider.md
@@ -49,7 +49,7 @@ If you can see your ports are open on canyouseeme.org while running the app and 
 
 1. `wget https://raw.githubusercontent.com/golemfactory/golem/develop/Installer/Installer_Linux/install.sh`
 2. `chmod +x install.sh`
-3. `./install.sh --deps-only`
+3. `./install.sh`
 
 Run Golem normally and it will build the required docker images if the prerequisites have been satisfied.
 

--- a/Products/Brass-Beta/Installation.md
+++ b/Products/Brass-Beta/Installation.md
@@ -761,7 +761,7 @@ The officially supported release is 16.04 at the moment.
 
 1. `wget https://raw.githubusercontent.com/golemfactory/golem/develop/Installer/Installer_Linux/install.sh`
 2. `chmod +x install.sh`
-3. `./install.sh --deps-only`
+3. `./install.sh`
 
 Run Golem normally and it will build the required docker images if the prerequisites have been satisfied.
 


### PR DESCRIPTION
Docs were previously not updated after code changed here: https://github.com/golemfactory/golem/commit/4c1dfd839de25133b216019b55ff1940c9b19d94

This PR corrects the suggestion of using --deps-only