### PR TITLE
gWasm backend=brass

### DIFF
--- a/Products/gWASM/Quick-start.md
+++ b/Products/gWASM/Quick-start.md
@@ -196,12 +196,12 @@ gwasm-runner target/wasm32-unknown-emscripten/release/hello_world.wasm
 
 In order to do so, you have to have **Golem Clay Beta** Installed on your machine. [Follow installation instructions](https://docs.golem.network/#/Products/Clay-Beta/Installation).
 
-> Remember that it is required to run Golem instance in the background during gWASM computations.
+> Remember that it is required to run Golem instance in the background during gWASM computations. Note, gwasm-runner will use `--backend=Brass` to connect to Golem. For Clay (previously Brass Beta, and the repo name remained unchanged) it should stay `--backend=Brass` on the command line.
 
 With your Golem node running, run the below command to compute your task on the Golem network:
 
 ```bash
-gwasm-runner --backend=Clay target/wasm32-unknown-emscripten/release/hello_world.wasm
+gwasm-runner --backend=Brass target/wasm32-unknown-emscripten/release/hello_world.wasm
 ```
 
 That's it!

--- a/Products/gWASM/Verification-in-gWASM.md
+++ b/Products/gWASM/Verification-in-gWASM.md
@@ -1,9 +1,9 @@
 # Verification scheme
 
-?> When requesting computation in external sources, the results should be verified whether they are correct. 
+?> When requesting computation in external sources, the results should be verified whether they are correct.
 
 In gWASM we adopted an approach similar to BOINC. Each subtask is sent to two providers. If the results match, then they are considered correct and providers are paid. If not, then third provider - arbiter - computes again this subtask. Its result is compared to the previous and matching two are paid. For more information you can read our blogpost [here](https://blog.golemproject.net/gwasm-verification/). This verification scheme we call Verification by Redundancy - VbR.
 
-Comparing results itself is a challenge. We ensured that computations in our [sandbox](https://docs.golem.network/#/Products/Brass-Beta/gWASM?id=sandboxing) are deterministic. It limits the usage in some cases but it allows for byte-to-byte comparison.
+Comparing results itself is a challenge. We ensured that computations in our [sandbox](Products/gWASM/Sandboxing?id=sandboxing) are deterministic. It limits the usage in some cases but it allows for byte-to-byte comparison.
 
 When you request a task with some subtasks, be aware that there will be two times more jobs/computations. When you list subtasks for a given job in CLI, you will find two times more results. Its is because of VbR.


### PR DESCRIPTION
This PR includes a fix for the quickstart guide incorrectly guiding the user to use `--backend=Clay` instead of `--backend=Brass` along with a note.

It also has a minor link fix to go to the correct section about sandboxing.